### PR TITLE
Adding logic for callback after aggregate api

### DIFF
--- a/src/main/java/org/mifos/processor/bulk/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/config/CamelProperties.java
@@ -35,6 +35,8 @@ public class CamelProperties {
 
     public static final String BATCH_STATUS_FAILED = "batchStatusFailed";
 
+    public static final String CALLBACK_RESPONSE_CODE = "responseCode";
+
     public static final String BATCH_REQUEST_TYPE = "batchRequestType";
 
 }

--- a/src/main/java/org/mifos/processor/bulk/camel/routes/ProcessorStartRoute.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/routes/ProcessorStartRoute.java
@@ -146,6 +146,9 @@ public class ProcessorStartRoute extends BaseRouteBuilder {
 
                     logger.info("File uploaded {}", nm);
 
+                    //extracting  and setting callback Url
+                    String callbackUrl = exchange.getIn().getHeader("Callback-Url", String.class);
+                    exchange.setProperty(CALLBACK_URL,callbackUrl);
 
                     Map<String, Object> variables = new HashMap<>();
                     variables.put(BATCH_ID, batchId);
@@ -153,6 +156,7 @@ public class ProcessorStartRoute extends BaseRouteBuilder {
                     variables.put(REQUEST_ID, requestId);
                     variables.put(PURPOSE, purpose);
                     variables.put(TENANT_ID, exchange.getProperty(TENANT_NAME));
+                    variables.put(CALLBACK_URL,callbackUrl);
                     setConfigProperties(variables);
 
                     JSONObject response = new JSONObject();
@@ -204,6 +208,9 @@ public class ProcessorStartRoute extends BaseRouteBuilder {
         variables.put(MAX_STATUS_RETRY, maxThresholdCheckRetry);
         variables.put(SUCCESS_THRESHOLD, successThreshold);
         variables.put(THRESHOLD_DELAY, Utils.getZeebeTimerValue(thresholdCheckDelay));
+        variables.put(BULK_NOTIF_SUCCESS,false);
+        variables.put(BULK_NOTIF_FAILURE,false);
+
         return variables;
     }
 

--- a/src/main/java/org/mifos/processor/bulk/camel/routes/RouteId.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/routes/RouteId.java
@@ -8,6 +8,7 @@ public enum RouteId {
     SPLITTING("direct:splitting"),
     FORMATTING("direct:formatting"),
     BATCH_STATUS("direct:batchStatus"),
+    SEND_CALLBACK("direct:sendCallback"),
     MERGE_BACK("direct:mergeSubBatch"),
     INIT_SUB_BATCH("direct:init-sub-batches");
 

--- a/src/main/java/org/mifos/processor/bulk/camel/routes/SendCallbackRoute.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/routes/SendCallbackRoute.java
@@ -1,0 +1,80 @@
+package org.mifos.processor.bulk.camel.routes;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.model.dataformat.JsonLibrary;
+import org.apache.camel.spi.AsEndpointUri;
+import org.mifos.processor.bulk.schema.BatchDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static org.mifos.processor.bulk.camel.config.CamelProperties.*;
+import static org.mifos.processor.bulk.zeebe.ZeebeVariables.*;
+
+@Component
+public class SendCallbackRoute extends BaseRouteBuilder {
+
+
+    @Value("${callback.url}")
+    private String callbackUrl;
+
+    @Override
+    public void configure() throws Exception {
+
+        from("rest:get:test/send/callback")
+                .to(RouteId.SEND_CALLBACK.getValue());
+
+        /**
+         * Base route for kicking off callback. Performs below tasks.
+         * Sends Callback to the set url
+         * Checks of response code is anything not 2xx then retries
+         */
+
+        from(RouteId.SEND_CALLBACK.getValue())
+                .id(RouteId.SEND_CALLBACK.getValue())
+                .log("Starting route " + RouteId.SEND_CALLBACK.name())
+                .log("Sending callback for Batch Processing")
+                .setBody(exchange -> {
+                    String body = "Batch Aggregation API was complete with %: " +
+                            exchange.getProperty(SUCCESS_RATE);
+                    callbackUrl = exchange.getProperty(CALLBACK_URL).toString();
+                    return body;
+                })
+                .toD("${header.callbackUrl}?bridgeEndpoint=true&throwExceptionOnFailure=false")
+                .choice()
+                .when(header("CamelHttpResponseCode").startsWith("2"))
+                .log(LoggingLevel.INFO, "Callback sending was successful")
+                .process(exchange -> {
+                    exchange.setProperty(CALLBACK_RESPONSE_CODE, exchange.getIn()
+                            .getHeader(Exchange.HTTP_RESPONSE_CODE));
+                    exchange.setProperty(CALLBACK_RETRY, 1);
+                    exchange.setProperty(CALLBACK_SUCCESS, true);
+
+                })
+                .otherwise()
+                .log(LoggingLevel.ERROR, "Callback request was unsuccessful")
+                .process(exchange -> {
+                    if (exchange.getProperty(CALLBACK_RETRY).equals(MAX_STATUS_RETRY)) {
+                        logger.info("Retry Exhausted, setting Callback as Failed");
+                    } else {
+                        int retry = (int) exchange.getProperty(CALLBACK_RETRY);
+                        retry++;
+                        logger.info("Retry Left {}, Setting Callback as Failed and Retrying...",
+                                ((int) exchange.getProperty(MAX_STATUS_RETRY) - retry));
+                        exchange.setProperty(CALLBACK_RETRY, retry);
+                        exchange.setProperty(CALLBACK_RESPONSE_CODE, exchange.getIn()
+                                .getHeader(Exchange.HTTP_RESPONSE_CODE));
+
+                    }
+                    exchange.setProperty(CALLBACK_SUCCESS, false);
+                    exchange.setProperty(ERROR_DESCRIPTION, exchange.getIn().getBody(String.class));
+                    exchange.setProperty(ERROR_CODE, exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE));
+                });
+
+        //for temporary callback simulation
+        from("rest:post:/simulate")
+                .log("Reached Simulation");
+    }
+
+
+}

--- a/src/main/java/org/mifos/processor/bulk/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/ZeebeVariables.java
@@ -87,6 +87,8 @@ public class ZeebeVariables {
 
     public static final String RETRY = "retry";
 
+    public static final String CALLBACK_RETRY = "callbackRetryCount";
+
     public static final String SUCCESS_THRESHOLD = "successThreshold";
 
     public static final String SUCCESS_RATE = "successRate";
@@ -98,4 +100,12 @@ public class ZeebeVariables {
     public static final String THRESHOLD_DELAY = "thresholdDelay";
 
     public static final String PAYMENT_MODE = "paymentMode";
+
+    public static final String CALLBACK_SUCCESS = "callbackSuccessful";
+
+    public static final String CALLBACK_URL = "callbackUrl";
+
+    public static final String BULK_NOTIF_SUCCESS = "isNotificationsSuccessEnabled";
+
+    public static final String BULK_NOTIF_FAILURE = "isNotificationsFailureEnabled";
 }

--- a/src/main/java/org/mifos/processor/bulk/zeebe/worker/SendCallbackWorker.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/worker/SendCallbackWorker.java
@@ -1,0 +1,48 @@
+package org.mifos.processor.bulk.zeebe.worker;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.support.DefaultExchange;
+import org.mifos.processor.bulk.camel.routes.RouteId;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.mifos.processor.bulk.camel.config.CamelProperties.BATCH_STATUS_FAILED;
+import static org.mifos.processor.bulk.camel.config.CamelProperties.CALLBACK_RESPONSE_CODE;
+import static org.mifos.processor.bulk.zeebe.ZeebeVariables.*;
+
+@Component
+public class SendCallbackWorker extends BaseWorker {
+
+    @Override
+    public void setup() {
+        newWorker(Worker.SEND_CALLBACK, (client, job) -> {
+            Map<String, Object> variables = job.getVariablesAsMap();
+
+            int retry = (int) variables.getOrDefault(CALLBACK_RETRY, 0);
+
+            Exchange exchange = new DefaultExchange(camelContext);
+            exchange.setProperty(MAX_STATUS_RETRY,variables.get(MAX_STATUS_RETRY));
+            exchange.setProperty(CALLBACK_RETRY,retry);
+            exchange.setProperty(CALLBACK_URL,variables.get(CALLBACK_URL));
+            exchange.setProperty(SUCCESS_RATE,variables.get(SUCCESS_RATE));
+            sendToCamelRoute(RouteId.SEND_CALLBACK, exchange);
+
+            Boolean callbackSuccess = exchange.getProperty(CALLBACK_SUCCESS, Boolean.class);
+            if (callbackSuccess == null || !callbackSuccess) {
+                variables.put(ERROR_CODE, exchange.getProperty(ERROR_CODE));
+                variables.put(ERROR_DESCRIPTION, exchange.getProperty(ERROR_DESCRIPTION));
+                logger.info("Error: {}, {}", variables.get(ERROR_CODE), variables.get(ERROR_DESCRIPTION));
+            } else {
+                variables.put(CALLBACK_SUCCESS,true);
+            }
+
+            variables.put(CALLBACK_RETRY,exchange.getProperty(CALLBACK_RETRY));
+            variables.put(CALLBACK_RESPONSE_CODE,exchange.getProperty(CALLBACK_RESPONSE_CODE));
+
+            logger.info("Retry: {} and Response Code {}", exchange.getProperty(CALLBACK_RETRY), exchange.getProperty(CALLBACK_RESPONSE_CODE));
+            client.newCompleteCommand(job.getKey()).variables(variables).send();
+        });
+    }
+
+}

--- a/src/main/java/org/mifos/processor/bulk/zeebe/worker/Worker.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/worker/Worker.java
@@ -8,6 +8,7 @@ public enum Worker {
     SPLITTING("splitting"),
     FORMATTING("formatting"),
     BATCH_STATUS("batchStatus"),
+    SEND_CALLBACK("sendCallback"),
     MERGE_BACK("mergeSubBatch"),
 
     INIT_SUB_BATCH("initSubBatch");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -89,3 +89,6 @@ config:
     success-threshold: 95 # in percentage
     max-retry: 4
     delay: 60 # in seconds
+
+callback:
+  url: "http://httpstat.us/503"


### PR DESCRIPTION
Implements the logic attached.

Note: Application.yml has a  default callback url that simulates non 2xx response code. There is also a simulate route to get 2xx response code from header callback url.


Also the response visible in ngrok is attached

@avikganguly01 and @fynmanoj : Please review


Design:
![Callback_Highlevel drawio](https://user-images.githubusercontent.com/92036361/191343589-3e00efde-6cc5-445b-97a9-c2fa32ddf7bd.png)


Ngrok:
<img width="1440" alt="Screenshot 2022-09-22 at 1 40 58 PM" src="https://user-images.githubusercontent.com/92036361/191697680-e000b5ef-2795-4d55-a59b-8c37e587c6b6.png">

