### PR TITLE
Fixes #27 Invalid RESULT_FILE zeebe variable value

### DIFF
--- a/src/main/java/org/mifos/processor/bulk/camel/routes/SplittingRoute.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/routes/SplittingRoute.java
@@ -54,6 +54,7 @@ public class SplittingRoute extends BaseRouteBuilder {
 
                     if (lines.size() <= subBatchSize) {
                         exchange.setProperty(SUB_BATCH_CREATED, false);
+                        exchange.setProperty(SERVER_SUB_BATCH_FILE_NAME_ARRAY, new ArrayList<String>());
                         logger.info("Skipping creating sub batch, as batch size is less than configured sub-batch size");
                         return;
                     }

--- a/src/main/java/org/mifos/processor/bulk/zeebe/worker/SplittingWorker.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/worker/SplittingWorker.java
@@ -46,7 +46,9 @@ public class SplittingWorker extends BaseWorker {
             Boolean subBatchCreated = exchange.getProperty(SUB_BATCH_CREATED, Boolean.class);
             Optional<Boolean> subBatchCreatedOptional = Optional.ofNullable(subBatchCreated);
             List<String> serverSubBatchFileList = exchange.getProperty(SERVER_SUB_BATCH_FILE_NAME_ARRAY, List.class);
-            if (subBatchCreatedOptional.isPresent() && !subBatchCreatedOptional.get() && serverSubBatchFileList.isEmpty()) {
+            Optional<List<String>> serverSubBatchFileListOptional = Optional.ofNullable(serverSubBatchFileList);
+            if (subBatchCreatedOptional.isPresent() && !subBatchCreatedOptional.get() &&
+                    serverSubBatchFileListOptional.isPresent() && serverSubBatchFileList.isEmpty()) {
                 // if no sub-batches is created, insert the original filename in sub batch array
                 serverSubBatchFileList.add(filename);
                 subBatchCreated = false;

--- a/src/main/java/org/mifos/processor/bulk/zeebe/worker/SplittingWorker.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/worker/SplittingWorker.java
@@ -4,12 +4,10 @@ import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
 import org.mifos.processor.bulk.camel.routes.RouteId;
 import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import static org.mifos.processor.bulk.camel.config.CamelProperties.*;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.*;
 
@@ -44,11 +42,9 @@ public class SplittingWorker extends BaseWorker {
             }
 
             Boolean subBatchCreated = exchange.getProperty(SUB_BATCH_CREATED, Boolean.class);
-            Optional<Boolean> subBatchCreatedOptional = Optional.ofNullable(subBatchCreated);
             List<String> serverSubBatchFileList = exchange.getProperty(SERVER_SUB_BATCH_FILE_NAME_ARRAY, List.class);
-            Optional<List<String>> serverSubBatchFileListOptional = Optional.ofNullable(serverSubBatchFileList);
-            if (subBatchCreatedOptional.isPresent() && !subBatchCreatedOptional.get() &&
-                    serverSubBatchFileListOptional.isPresent() && serverSubBatchFileList.isEmpty()) {
+            if (subBatchCreated != null && !subBatchCreated &&
+                    serverSubBatchFileList != null && serverSubBatchFileList.isEmpty()) {
                 // if no sub-batches is created, insert the original filename in sub batch array
                 serverSubBatchFileList.add(filename);
                 subBatchCreated = false;


### PR DESCRIPTION
Updates in this PR
1. `RESULT_FILE` zeebe variable value fixed, in case of single sub-batch no split.
2. Null pointer issue fixed for splitting worker.