### PR TITLE
Minor bug fix for variable name

### DIFF
--- a/src/main/java/org/mifos/processor/bulk/utility/PhaseUtils.java
+++ b/src/main/java/org/mifos/processor/bulk/utility/PhaseUtils.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-@ConfigurationProperties(prefix = "callback_phases")
+@ConfigurationProperties(prefix = "callback-phases")
 public class PhaseUtils {
 
     private List<Integer> values;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -117,7 +117,7 @@ callback:
   url: "http://httpstat.us/503"
 
 
-callback_phases:
+callback-phases:
   values:
     - 20
     - 40


### PR DESCRIPTION
## Description

This is to fix issue:

````
***************************
APPLICATION FAILED TO START
***************************
Description:
Configuration property name 'callback_phases' is not valid:
Invalid characters: '_'
Bean: processorStartRoute
Reason: Canonical names should be kebab-case ('-' separated), lowercase alpha-numeric characters and must start with a letter
Action:
Modify 'callback_phases' so that it conforms to the canonical names requirements.
````

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
