### PR TITLE
Upgraded the heap size,min heap free ratio and gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ configurations {
     }
 }
 
+tasks.withType(JavaExec) {
+    jvmArgs = ['-Xms400m', '-Xmx400m','-XX:MinHeapFreeRatio=30']
+}
+
 task cucumberCli() {
     dependsOn assemble, testClasses
     doLast {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

- Allocate more memory and update min heap free ration

- Upgraded gradle version for compatibility with java 17

Proof :
![Heap size upgraded](https://github.com/openMF/ph-ee-bulk-processor/assets/78945411/3b253ecb-10ee-43ad-9c7c-75790fe34880)



 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Design related bullet points or design document link related to this PR added in the description above. 

- [X] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [X] Create/update unit or integration tests for verifying the changes made.

- [X] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [X] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
