### PR TITLE
PHEE-427: Channel service is https hence making default hostname as https

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,7 +38,7 @@ operations-app:
     batch-transaction: "/api/v1/batch/transactions"
 
 channel:
-  hostname: "http://ph-ee-connector-channel"
+  hostname: "https://ph-ee-connector-channel"
 
 cloud:
   aws:


### PR DESCRIPTION
[PHEE-427](https://fynarfin.atlassian.net/browse/PHEE-427)

[PHEE-427]: https://fynarfin.atlassian.net/browse/PHEE-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ