### PR TITLE
Patch Gov-325: Renamed the zeebe variable duplicatxnfile to failedTxnFile

### DIFF
--- a/src/main/java/org/mifos/processor/bulk/camel/routes/DeDuplicationRoute.java
+++ b/src/main/java/org/mifos/processor/bulk/camel/routes/DeDuplicationRoute.java
@@ -8,7 +8,7 @@ import static org.mifos.processor.bulk.camel.config.CamelProperties.SERVER_FILE_
 import static org.mifos.processor.bulk.camel.config.CamelProperties.TRANSACTION_LIST;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DE_DUPLICATION_FAILED;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DUPLICATE_TRANSACTION_COUNT;
-import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DUPLICATE_TRANSACTION_FILE;
+import static org.mifos.processor.bulk.zeebe.ZeebeVariables.FAILED_TRANSACTION_FILE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,10 +67,10 @@ public class DeDuplicationRoute extends BaseRouteBuilder {
                     String originalFileServerName = exchange.getProperty(SERVER_FILE_NAME, String.class);
                     String duplicateFileName = "duplicate_transaction_" + originalFileServerName;
 
-                    exchange.setProperty(DUPLICATE_TRANSACTION_FILE, duplicateFileName);
+                    exchange.setProperty(FAILED_TRANSACTION_FILE, duplicateFileName);
                 }).log("Updating duplicate transaction list")
                 .setProperty(TRANSACTION_LIST, simple("${exchangeProperty." + DUPLICATE_TRANSACTION_LIST + "}"))
-                .setProperty(LOCAL_FILE_PATH, simple("${exchangeProperty." + DUPLICATE_TRANSACTION_FILE + "}"))
+                .setProperty(LOCAL_FILE_PATH, simple("${exchangeProperty." + FAILED_TRANSACTION_FILE + "}"))
                 .setProperty(OVERRIDE_HEADER, constant(true)).to("direct:update-file").to("direct:upload-file").process(exchange -> {
                     // checking if file upload was success or
                     String serverFileName = exchange.getProperty(SERVER_FILE_NAME, String.class);

--- a/src/main/java/org/mifos/processor/bulk/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/ZeebeVariables.java
@@ -160,7 +160,7 @@ public final class ZeebeVariables {
 
     public static final String AUTHORIZATION_RESPONSE = "authorizationResponse";
 
-    public static final String DUPLICATE_TRANSACTION_FILE = "duplicateTransactionFile";
+    public static final String FAILED_TRANSACTION_FILE = "failedTransactionFile";
 
     public static final String DUPLICATE_TRANSACTION_COUNT = "duplicateTransactionCount";
 

--- a/src/main/java/org/mifos/processor/bulk/zeebe/worker/DeDuplicationWorker.java
+++ b/src/main/java/org/mifos/processor/bulk/zeebe/worker/DeDuplicationWorker.java
@@ -4,7 +4,7 @@ import static org.mifos.processor.bulk.camel.config.CamelProperties.SERVER_FILE_
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DE_DUPLICATION_ENABLE;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DE_DUPLICATION_FAILED;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DUPLICATE_TRANSACTION_COUNT;
-import static org.mifos.processor.bulk.zeebe.ZeebeVariables.DUPLICATE_TRANSACTION_FILE;
+import static org.mifos.processor.bulk.zeebe.ZeebeVariables.FAILED_TRANSACTION_FILE;
 import static org.mifos.processor.bulk.zeebe.ZeebeVariables.FILE_NAME;
 
 import java.util.Map;
@@ -41,7 +41,7 @@ public class DeDuplicationWorker extends BaseWorker {
             int duplicateTransactionCount = exchange.getProperty(DUPLICATE_TRANSACTION_COUNT, Integer.class);
             if (duplicateTransactionCount > 0) {
                 // if duplicate txn exist
-                variables.put(DUPLICATE_TRANSACTION_FILE, exchange.getProperty(DUPLICATE_TRANSACTION_FILE, String.class));
+                variables.put(FAILED_TRANSACTION_FILE, exchange.getProperty(FAILED_TRANSACTION_FILE, String.class));
             }
             variables.put(DE_DUPLICATION_FAILED, deDuplicationFailed);
             variables.put(DUPLICATE_TRANSACTION_COUNT, duplicateTransactionCount);


### PR DESCRIPTION
[GOV-325](https://mifosforge.jira.com/browse/GOV-325)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above.

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing

[GOV-325]: https://mifosforge.jira.com/browse/GOV-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ